### PR TITLE
Android integration (QPython)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 1. To use this app on Android you need to download [QPython](https://github.com/qpython-android/qpython/releases/tag/3.0.1) on your devise. <!-- There must be a link to Google Play Store but I couldn't reach it -->
 2. Download our app archive from GitHub repository
 3. Extract archive on `Phone Storage/qpython/projects3/` folder.
-4. Go to `shedlib/Parsering/parsing.py` and change `Parser.__datadir` value to `"projects3/Lifor-<YOUR-LIFOR-VERSION>/.data"`
-5. Change `datadir` value to `"projects3/Lifor-<YOUR-LIFOR-VERSION>/.data"`
-6. Set your daily schedule. Run `setSchedule.py` and follow instructions.
+4. Set your daily schedule. Run `setSchedule.py` and follow instructions.
 
 To use app you need to:
 1. Open QPython application on your devise.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from shedlib.Time.Time import Time as Time
 import time
 import os
 
+__VERSION__ = "0.1.1"
 
 def main():
     """Main function"""
@@ -39,11 +40,10 @@ def settingProgrammUp():
     So, here we moves programm to it's normal place if it's in 'qpython' folder
     """
     if os.path.split( os.getcwd() )[-1] == "qpython":
-        # star works only if there is only one version installed
-        # must be replaced later with better solution
-        os.system("cd projects3/Lifor-*")
+        os.chdir(f"projects3/Lifor-{__VERSION__}")
+
 
 if __name__ == "__main__":
     settingProgrammUp()
-    # main()
-    # quit()
+    main()
+    quit()

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def settingProgrammUp():
     if os.path.split( os.getcwd() )[-1] == "qpython":
         # star works only if there is only one version installed
         # must be replaced later with better solution
-        os.chdir("projects3/Lifor-*")
+        os.system("cd projects3/Lifor-*")
 
 if __name__ == "__main__":
     settingProgrammUp()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from shedlib.UI.ConsoleInterface import ConsoleInterface as ConsoleInterface
 from shedlib.Parsing.parsing import Parser as Parser
 from shedlib.Time.Time import Time as Time
 import time
+import os
 
 
 def main():
@@ -31,7 +32,18 @@ def main():
         time.sleep(1)
 
 
+def settingProgrammUp():
+    """ 
+    This module sets programm up working 
+    on qpython platform. By default it runs as at qpythons root directory
+    So, here we moves programm to it's normal place if it's in 'qpython' folder
+    """
+    if os.path.split( os.getcwd() )[-1] == "qpython":
+        # star works only if there is only one version installed
+        # must be replaced later with better solution
+        os.chdir("projects3/Lifor-*")
 
 if __name__ == "__main__":
-    main()
-    quit()
+    settingProgrammUp()
+    # main()
+    # quit()


### PR DESCRIPTION
Added integration with QPython.
When you start script, QPython starts it at it's root directory `Phone Storage/qpython` and don't allow script to access it's own library and user data it contain. In order to solve that problem, at script start we go to `qpython/projects` directory.
Also we change user instruction little bit, removing useless information for him. Now user may not change code of app to make app work.